### PR TITLE
Type hint fixed: method parameter should be a CustomerOrderItem

### DIFF
--- a/src/Mapper/CustomerOrder.php
+++ b/src/Mapper/CustomerOrder.php
@@ -439,7 +439,7 @@ class CustomerOrder extends DataMapper
             ->setDetails($detailsSW);
     }
 
-    protected function prepareItemAssociatedData(CustomerOrderModel &$item, OrderSW &$orderSW, \Doctrine\Common\Collections\ArrayCollection &$detailsSW)
+    protected function prepareItemAssociatedData(CustomerOrderItem &$item, OrderSW &$orderSW, \Doctrine\Common\Collections\ArrayCollection &$detailsSW)
     {
         $detailSW = null;
 


### PR DESCRIPTION
The prepareItemAssociatedData method is expects an CustomerOrderItem. The (currently) wrong type hint leads to and error message after each JTL sync with the connector.